### PR TITLE
Bug fix in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Instructions
 drush make \
   https://raw.github.com/RiaanBurger/drupal-remix/master/extra/build-remix.make \
   -y --prepare-install \
-  && rm -rf sites/all/{modules,themes} \
+  && rm -rf sites/all/{libraries,modules,themes} \
   && mv profiles/remix/{libraries,modules,themes} sites/all/
 ```
 - Access your website in the browser to complete your Drupal Remix installation.


### PR DESCRIPTION
Fixes "mv: cannot move ‘profiles/remix/libraries’ to ‘sites/all/libraries’: Directory not empty
"
Fixes #12 :
With verbose flag on last two arguments:
`removed ‘sites/all/libraries/README.txt’
removed directory: ‘sites/all/libraries’
removed ‘sites/all/modules/README.txt’
removed directory: ‘sites/all/modules’
removed ‘sites/all/themes/README.txt’
removed directory: ‘sites/all/themes’
‘profiles/remix/libraries’ -> ‘sites/all/libraries’
‘profiles/remix/modules’ -> ‘sites/all/modules’
‘profiles/remix/themes’ -> ‘sites/all/themes’
`